### PR TITLE
Set soft limit lower than the hard limit

### DIFF
--- a/spook.rb
+++ b/spook.rb
@@ -29,7 +29,7 @@ class Spook < Formula
       <string>launchctl</string>
       <string>limit</string>
       <string>maxfiles</string>
-      <string>524288</string>
+      <string>64000</string>
       <string>524288</string>
     </array>
     <key>RunAtLoad</key>


### PR DESCRIPTION
The soft limit is the value that the kernel enforces for the corresponding resource. The hard limit acts as a ceiling for the soft limit.