### PR TITLE
Use limit.maxproc when setting maxproc value

### DIFF
--- a/spook.rb
+++ b/spook.rb
@@ -43,12 +43,12 @@ class Spook < Formula
 <plist version="1.0">
   <dict>
     <key>Label</key>
-    <string>limit.maxfiles</string>
+    <string>limit.maxproc</string>
     <key>ProgramArguments</key>
     <array>
       <string>launchctl</string>
       <string>limit</string>
-      <string>maxfiles</string>
+      <string>maxproc</string>
       <string>524288</string>
       <string>524288</string>
     </array>

--- a/spook.rb
+++ b/spook.rb
@@ -49,8 +49,8 @@ class Spook < Formula
       <string>launchctl</string>
       <string>limit</string>
       <string>maxproc</string>
-      <string>524288</string>
-      <string>524288</string>
+      <string>2048</string>
+      <string>2048</string>
     </array>
     <key>RunAtLoad</key>
     <true/>


### PR DESCRIPTION
Setting a more sensible value for `maxproc`. Also, second file limit.maxproc.plist should have configuration for maxproc.